### PR TITLE
Warn the user when accessing publicized members

### DIFF
--- a/BepInEx.Analyzers/BepInEx.Analyzers/AccessPublicizedMemberAnalyzer.cs
+++ b/BepInEx.Analyzers/BepInEx.Analyzers/AccessPublicizedMemberAnalyzer.cs
@@ -1,0 +1,45 @@
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+using System.Collections.Immutable;
+
+namespace BepInEx.Analyzers
+{
+    [DiagnosticAnalyzer(LanguageNames.CSharp)]
+    public class AccessPublicizedMemberAnalyzer : DiagnosticAnalyzer
+    {
+        public const string DiagnosticId = "Publicizer001";
+
+        private static readonly LocalizableString Title = new LocalizableResourceString(nameof(Resources.AccessPublicizedMemberAnalyzerTitle), Resources.ResourceManager, typeof(Resources));
+        private static readonly LocalizableString MessageFormat = new LocalizableResourceString(nameof(Resources.AccessPublicizedMemberAnalyzerMessageFormat), Resources.ResourceManager, typeof(Resources));
+        private static readonly LocalizableString Description = new LocalizableResourceString(nameof(Resources.AccessPublicizedMemberAnalyzerDescription), Resources.ResourceManager, typeof(Resources));
+        private const string Category = "Member Access";
+        private static readonly DiagnosticDescriptor Rule = new DiagnosticDescriptor(DiagnosticId, Title, MessageFormat, Category, DiagnosticSeverity.Warning, true, Description);
+
+        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Rule);
+
+        private const string PublicizedAttributeName = "System.Runtime.CompilerServices.PublicizedAttribute";
+
+        public override void Initialize(AnalysisContext context)
+        {
+            context.EnableConcurrentExecution();
+            context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+            context.RegisterSyntaxNodeAction(AnalyzeSimpleMemberAccess, SyntaxKind.SimpleMemberAccessExpression);
+        }
+
+        private void AnalyzeSimpleMemberAccess(SyntaxNodeAnalysisContext context)
+        {
+            var memberAccess = (MemberAccessExpressionSyntax)context.Node;
+            var symbol = context.SemanticModel.GetSymbolInfo(memberAccess.Name, context.CancellationToken).Symbol;
+
+            if (IsPublicized(symbol))
+            {
+                context.ReportDiagnostic(Diagnostic.Create(Rule, memberAccess.Name.GetLocation(), memberAccess.Name.Identifier));
+            }
+        }
+
+        private static bool IsPublicized(ISymbol symbol) =>
+            symbol != null && symbol.HasAttribute(PublicizedAttributeName);
+    }
+}

--- a/BepInEx.Analyzers/BepInEx.Analyzers/Resources.Designer.cs
+++ b/BepInEx.Analyzers/BepInEx.Analyzers/Resources.Designer.cs
@@ -61,6 +61,33 @@ namespace BepInEx.Analyzers {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Accessing a member that was not originally public.
+        /// </summary>
+        internal static string AccessPublicizedMemberAnalyzerDescription {
+            get {
+                return ResourceManager.GetString("AccessPublicizedMemberAnalyzerDescription", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Forced access of {0} can lead to unintended behavior. Check for public members first..
+        /// </summary>
+        internal static string AccessPublicizedMemberAnalyzerMessageFormat {
+            get {
+                return ResourceManager.GetString("AccessPublicizedMemberAnalyzerMessageFormat", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Accessing a member that was not originally public.
+        /// </summary>
+        internal static string AccessPublicizedMemberAnalyzerTitle {
+            get {
+                return ResourceManager.GetString("AccessPublicizedMemberAnalyzerTitle", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Classes inheriting from BaseUnityPlugin should have a BepInPlugin attribute..
         /// </summary>
         internal static string BepInExMissingAttributeAnalyzerDescription {

--- a/BepInEx.Analyzers/BepInEx.Analyzers/Resources.resx
+++ b/BepInEx.Analyzers/BepInEx.Analyzers/Resources.resx
@@ -117,6 +117,15 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
+  <data name="AccessPublicizedMemberAnalyzerDescription" xml:space="preserve">
+    <value>Accessing a member that was not originally public</value>
+  </data>
+  <data name="AccessPublicizedMemberAnalyzerMessageFormat" xml:space="preserve">
+    <value>Forced access of {0} can lead to unintended behavior. Check for public members first.</value>
+  </data>
+  <data name="AccessPublicizedMemberAnalyzerTitle" xml:space="preserve">
+    <value>Accessing a member that was not originally public</value>
+  </data>
   <data name="BepInExMissingAttributeAnalyzerDescription" xml:space="preserve">
     <value>Classes inheriting from BaseUnityPlugin should have a BepInPlugin attribute.</value>
   </data>


### PR DESCRIPTION
Add an analyzer warning when the user try to access a member that is originally private