### PR TITLE
Do not show the publicizer warning when publicized members are used inside class/subclass they are declared in

### DIFF
--- a/BepInEx.Analyzers/BepInEx.Analyzers.Package/BepInEx.Analyzers.Package.csproj
+++ b/BepInEx.Analyzers/BepInEx.Analyzers.Package/BepInEx.Analyzers.Package.csproj
@@ -11,7 +11,7 @@
 
   <PropertyGroup>
     <PackageId>BepInEx.Analyzers</PackageId>
-    <PackageVersion>1.0.5</PackageVersion>
+    <PackageVersion>1.0.6</PackageVersion>
     <Authors>BepInEx</Authors>
     <PackageProjectUrl>https://github.com/BepInEx/BepInEx.Analyzers</PackageProjectUrl>
     <PackageIconUrl>https://avatars2.githubusercontent.com/u/39589027</PackageIconUrl>

--- a/BepInEx.Analyzers/BepInEx.Analyzers/AccessPublicizedMemberAnalyzer.cs
+++ b/BepInEx.Analyzers/BepInEx.Analyzers/AccessPublicizedMemberAnalyzer.cs
@@ -2,6 +2,7 @@ using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Diagnostics;
+using System;
 using System.Collections.Immutable;
 
 namespace BepInEx.Analyzers
@@ -55,30 +56,27 @@ namespace BepInEx.Analyzers
                 if (propertyUsage == Extensions.PropertyUsage.Get || propertyUsage == Extensions.PropertyUsage.GetAndSet)
                 {
                     var getMethodPublicizedAttribute = propertySymbol.GetMethod.GetAttribute(PublicizedAttributeName);
-                    if (getMethodPublicizedAttribute != null)
-                    {
-                        var accessibility = GetAccessModifier(getMethodPublicizedAttribute);
-                        Check(accessibility, symbol, context, memberAccess);
-                    }
+                    Check(getMethodPublicizedAttribute, symbol, context, memberAccess);
                 }
                 else
                 {
                     var setMethodPublicizedAttribute = propertySymbol.SetMethod.GetAttribute(PublicizedAttributeName);
-                    if (setMethodPublicizedAttribute != null)
-                    {
-                        var accessibility = GetAccessModifier(setMethodPublicizedAttribute);
-                        Check(accessibility, symbol, context, memberAccess);
-                    }
+                    Check(setMethodPublicizedAttribute, symbol, context, memberAccess);
                 }
             }
             else
             {
                 var publicizedAttribute = symbol.GetAttribute(PublicizedAttributeName);
-                if (publicizedAttribute != null)
-                {
-                    var accessibility = GetAccessModifier(publicizedAttribute);
-                    Check(accessibility, symbol, context, memberAccess);
-                }
+                Check(publicizedAttribute, symbol, context, memberAccess);
+            }
+        }
+
+        private void Check(AttributeData attribute, ISymbol symbol, SyntaxNodeAnalysisContext context, MemberAccessExpressionSyntax memberAccess)
+        {
+            if (attribute != null)
+            {
+                var accessibility = GetAccessModifier(attribute);
+                Check(accessibility, symbol, context, memberAccess);
             }
         }
 

--- a/BepInEx.Analyzers/BepInEx.Analyzers/AccessPublicizedMemberAnalyzer.cs
+++ b/BepInEx.Analyzers/BepInEx.Analyzers/AccessPublicizedMemberAnalyzer.cs
@@ -3,7 +3,6 @@ using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Diagnostics;
 using System.Collections.Immutable;
-using System.Linq;
 
 namespace BepInEx.Analyzers
 {
@@ -65,7 +64,7 @@ namespace BepInEx.Analyzers
 
         private static bool IsPrivateAndPublicized(ISymbol symbol)
         {
-            var publicizedAttribute = symbol.GetAttributes().FirstOrDefault(a => a.AttributeClass.Name == PublicizedAttributeName);
+            var publicizedAttribute = symbol.GetAttribute(PublicizedAttributeName);
             if (publicizedAttribute == null)
                 return false;
 

--- a/BepInEx.Analyzers/BepInEx.Analyzers/Extensions.cs
+++ b/BepInEx.Analyzers/BepInEx.Analyzers/Extensions.cs
@@ -87,6 +87,11 @@ namespace BepInEx.Analyzers
             return symbol.GetAttributes().Any(x => x.AttributeClass.ToString() == typeName);
         }
 
+        public static AttributeData GetAttribute(this ISymbol symbol, string typeName)
+        {
+            return symbol.GetAttributes().FirstOrDefault(x => x.AttributeClass.ToString() == typeName);
+        }
+
         public static bool IsStatic(this MethodDeclarationSyntax methodDeclaration)
         {
             return methodDeclaration.Modifiers.Any(x => x.Kind() == SyntaxKind.StaticKeyword);

--- a/BepInEx.Analyzers/BepInEx.Analyzers/Extensions.cs
+++ b/BepInEx.Analyzers/BepInEx.Analyzers/Extensions.cs
@@ -115,5 +115,60 @@ namespace BepInEx.Analyzers
                 .SelectMany(nestedType => GetNestedTypes(nestedType)))
                 yield return nestedType;
         }
+
+        public enum PropertyUsage
+        {
+            Get,
+            Set,
+            GetAndSet
+        }
+
+        // https://github.com/dotnet/roslyn/issues/15527
+        // Allow to figure how the property was used,
+        // Through its getter, or setter, or both.
+        //
+        // ++/--    pre/postfix increments            get/set
+        // =        lhs of simple assignments         set
+        // +=, -=   lhs of other assigments           get/set
+        // x.y      rhs, of compound member access    recurr up
+        //
+        // any other use is just a get
+        //
+        // TOOD: ref parameters?
+        //
+        public static PropertyUsage GetPropertyUsage(this SyntaxNode node)
+        {
+            var kind = node.Parent.Kind();
+
+            if (kind == SyntaxKind.PostIncrementExpression ||
+                kind == SyntaxKind.PostDecrementExpression ||
+                kind == SyntaxKind.PreIncrementExpression ||
+                kind == SyntaxKind.PreDecrementExpression)
+            {
+                return PropertyUsage.GetAndSet;
+            }
+            else if (node.Parent is AssignmentExpressionSyntax)
+            {
+                var assignment = (AssignmentExpressionSyntax)(node.Parent);
+
+                if (assignment.Left == node)
+                {
+                    return kind == SyntaxKind.SimpleAssignmentExpression
+                        ? PropertyUsage.Set
+                        : PropertyUsage.GetAndSet;
+                }
+            }
+            else if (node.Parent is MemberAccessExpressionSyntax)
+            {
+                var m = (MemberAccessExpressionSyntax)(node.Parent);
+
+                if (m.Name == node)
+                {
+                    return node.Parent.GetPropertyUsage();
+                }
+            }
+
+            return PropertyUsage.Get;
+        }
     }
 }

--- a/BepInEx.Analyzers/BepInEx.Analyzers/HarmonyMethodRefParametersAnalyzer.cs
+++ b/BepInEx.Analyzers/BepInEx.Analyzers/HarmonyMethodRefParametersAnalyzer.cs
@@ -34,7 +34,7 @@ namespace BepInEx.Analyzers
             var method = (MethodDeclarationSyntax)context.Node;
             var symbol = context.SemanticModel.GetDeclaredSymbol(method, context.CancellationToken);
 
-            if (!HarmonyUtil.IsMethodHarmonyRelated(ref context, method, symbol))
+            if (!HarmonyUtil.IsMethodHarmonyPatchRelated(ref context, method, symbol))
                 return;
 
             if (method.ParameterList?.Parameters.Count <= 0)

--- a/BepInEx.Analyzers/BepInEx.Analyzers/HarmonyMethodRefParametersAnalyzer.cs
+++ b/BepInEx.Analyzers/BepInEx.Analyzers/HarmonyMethodRefParametersAnalyzer.cs
@@ -2,10 +2,8 @@ using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Diagnostics;
-using System.Collections;
 using System.Collections.Generic;
 using System.Collections.Immutable;
-using System.IO;
 using System.Linq;
 
 namespace BepInEx.Analyzers

--- a/BepInEx.Analyzers/BepInEx.Analyzers/HarmonyMethodRefParametersAnalyzer.cs
+++ b/BepInEx.Analyzers/BepInEx.Analyzers/HarmonyMethodRefParametersAnalyzer.cs
@@ -1,0 +1,61 @@
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+using System.Collections.Immutable;
+using System.IO;
+using System.Linq;
+
+namespace BepInEx.Analyzers
+{
+    [DiagnosticAnalyzer(LanguageNames.CSharp)]
+    public class HarmonyMethodRefParametersAnalyzer : DiagnosticAnalyzer
+    {
+        public const string DiagnosticId = "Harmony003";
+
+        private static readonly LocalizableString Title = new LocalizableResourceString(nameof(Resources.HarmonyMethodRefParametersAnalyzerTitle), Resources.ResourceManager, typeof(Resources));
+        private static readonly LocalizableString MessageFormat = new LocalizableResourceString(nameof(Resources.HarmonyMethodRefParametersAnalyzerMessageFormat), Resources.ResourceManager, typeof(Resources));
+        private static readonly LocalizableString Description = new LocalizableResourceString(nameof(Resources.HarmonyMethodRefParametersAnalyzerDescription), Resources.ResourceManager, typeof(Resources));
+        private const string Category = "Method Declaration";
+
+        private static readonly DiagnosticDescriptor Rule = new DiagnosticDescriptor(DiagnosticId, Title, MessageFormat, Category, DiagnosticSeverity.Warning, true, Description);
+
+        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Rule);
+
+        public override void Initialize(AnalysisContext context)
+        {
+            context.EnableConcurrentExecution();
+            context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+            context.RegisterSyntaxNodeAction(AnalyzeMethodDeclaration, SyntaxKind.MethodDeclaration);
+        }
+
+        private void AnalyzeMethodDeclaration(SyntaxNodeAnalysisContext context)
+        {
+            var method = (MethodDeclarationSyntax)context.Node;
+            var symbol = context.SemanticModel.GetDeclaredSymbol(method, context.CancellationToken);
+
+            if (!HarmonyUtil.IsMethodHarmonyRelated(ref context, method, symbol))
+                return;
+
+            if (method.ParameterList?.Parameters.Count <= 0)
+                return;
+
+            var assignments = context.Node.DescendantNodes().OfType<AssignmentExpressionSyntax>();
+
+            foreach (var assignment in assignments)
+            {
+                var varName = assignment.Left.ToString();
+
+                foreach (var parameter in method.ParameterList.Parameters)
+                {
+                    var parameterSplit = parameter.ToString().Split(' ');
+                    if (parameterSplit.Any(s => s == varName) && !parameterSplit.Any(s => s == "ref"))
+                    {
+                        context.ReportDiagnostic(Diagnostic.Create(Rule, assignment.GetLocation(), assignment.ToString()));
+                    }
+                }
+            }
+
+        }
+    }
+}

--- a/BepInEx.Analyzers/BepInEx.Analyzers/HarmonyMethodRefParametersAnalyzer.cs
+++ b/BepInEx.Analyzers/BepInEx.Analyzers/HarmonyMethodRefParametersAnalyzer.cs
@@ -62,6 +62,16 @@ namespace BepInEx.Analyzers
             {
                 foreach (var parameter in method.ParameterList.Parameters)
                 {
+                    // If parameter is a reference type and is not a literal assignment no warning needed
+                    if (context.SemanticModel.GetDeclaredSymbol(parameter, context.CancellationToken).Type.IsReferenceType)
+                    {
+                        if (!(expressionSyntaxes[i] is AssignmentExpressionSyntax assignment))
+                        {
+                            continue;
+                        }
+                    }
+
+                    // TODO : Looking through the ToString() and "ref" is not the cleanest
                     var parameterSplit = parameter.ToString().Split(' ');
                     if (parameterSplit.Any(s => s == varNames[i]) && !parameterSplit.Any(s => s == "ref"))
                     {

--- a/BepInEx.Analyzers/BepInEx.Analyzers/HarmonyPrivateMethodSuppressor.cs
+++ b/BepInEx.Analyzers/BepInEx.Analyzers/HarmonyPrivateMethodSuppressor.cs
@@ -37,13 +37,7 @@ namespace BepInEx.Analyzers
 
             var symbol = semanticModel.GetDeclaredSymbol(method, context.CancellationToken);
 
-            //Check if the method or the class containing the method has Harmony related attributes
-            bool hasHarmonyAttributes = symbol.HasAttribute(TypeNames.HarmonyPatch);
-            if (!hasHarmonyAttributes)
-                if (method.Parent is ClassDeclarationSyntax classDeclaration)
-                    if (symbol.HasAttribute(TypeNames.HarmonyPatch))
-                        hasHarmonyAttributes = true;
-            if (!hasHarmonyAttributes)
+            if (!HarmonyUtil.IsMethodHarmonyRelated(ref context, semanticModel, method, symbol))
                 return;
 
             foreach(var descriptor in SupportedSuppressions.Where(d => d.SuppressedDiagnosticId == diagnostic.Id))

--- a/BepInEx.Analyzers/BepInEx.Analyzers/HarmonyPrivateMethodSuppressor.cs
+++ b/BepInEx.Analyzers/BepInEx.Analyzers/HarmonyPrivateMethodSuppressor.cs
@@ -37,7 +37,7 @@ namespace BepInEx.Analyzers
 
             var symbol = semanticModel.GetDeclaredSymbol(method, context.CancellationToken);
 
-            if (!HarmonyUtil.IsMethodHarmonyRelated(ref context, semanticModel, method, symbol))
+            if (!HarmonyUtil.IsMethodHarmonyPatchRelated(ref context, semanticModel, method, symbol))
                 return;
 
             foreach(var descriptor in SupportedSuppressions.Where(d => d.SuppressedDiagnosticId == diagnostic.Id))

--- a/BepInEx.Analyzers/BepInEx.Analyzers/HarmonyPropertyPatchAnalyzer.cs
+++ b/BepInEx.Analyzers/BepInEx.Analyzers/HarmonyPropertyPatchAnalyzer.cs
@@ -32,7 +32,7 @@ namespace BepInEx.Analyzers
             var attribute = (AttributeSyntax)context.Node;
 
             var symbol = context.SemanticModel.GetSymbolInfo(attribute, context.CancellationToken).Symbol;
-            if (symbol != null && attribute.ArgumentList != null && symbol.ContainingType?.ToString() == "HarmonyLib.HarmonyPatch")
+            if (symbol != null && attribute.ArgumentList != null && symbol.ContainingType?.ToString() == TypeNames.HarmonyPatch)
             {
                 foreach (var argument in attribute.ArgumentList.Arguments)
                 {

--- a/BepInEx.Analyzers/BepInEx.Analyzers/HarmonyPropertyPatchAnalyzer.cs
+++ b/BepInEx.Analyzers/BepInEx.Analyzers/HarmonyPropertyPatchAnalyzer.cs
@@ -32,7 +32,7 @@ namespace BepInEx.Analyzers
             var attribute = (AttributeSyntax)context.Node;
 
             var symbol = context.SemanticModel.GetSymbolInfo(attribute, context.CancellationToken).Symbol;
-            if (symbol != null && symbol.ContainingType.ToString() == "HarmonyLib.HarmonyPatch")
+            if (symbol != null && attribute.ArgumentList != null && symbol.ContainingType?.ToString() == "HarmonyLib.HarmonyPatch")
             {
                 foreach (var argument in attribute.ArgumentList.Arguments)
                 {

--- a/BepInEx.Analyzers/BepInEx.Analyzers/HarmonyUtil.cs
+++ b/BepInEx.Analyzers/BepInEx.Analyzers/HarmonyUtil.cs
@@ -1,0 +1,31 @@
+﻿using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace BepInEx.Analyzers
+{
+    public static class HarmonyUtil
+    {
+        // Check if the method or the class containing the method has Harmony related attributes
+        public static bool IsMethodHarmonyRelated(ref SyntaxNodeAnalysisContext context, MethodDeclarationSyntax method, ISymbol symbol)
+        {
+            bool hasHarmonyAttributes = symbol.HasAttribute(TypeNames.HarmonyPatch);
+            if (!hasHarmonyAttributes)
+                if (method.Parent is ClassDeclarationSyntax classDeclaration)
+                    if (context.SemanticModel.GetDeclaredSymbol(classDeclaration, context.CancellationToken).HasAttribute(TypeNames.HarmonyPatch))
+                        hasHarmonyAttributes = true;
+            return hasHarmonyAttributes;
+        }
+
+        // Same as above but from a SuppressionAnalysisContext context
+        public static bool IsMethodHarmonyRelated(ref SuppressionAnalysisContext context, SemanticModel semanticModel, MethodDeclarationSyntax method, ISymbol symbol)
+        {
+            bool hasHarmonyAttributes = symbol.HasAttribute(TypeNames.HarmonyPatch);
+            if (!hasHarmonyAttributes)
+                if (method.Parent is ClassDeclarationSyntax classDeclaration)
+                    if (semanticModel.GetDeclaredSymbol(classDeclaration, context.CancellationToken).HasAttribute(TypeNames.HarmonyPatch))
+                        hasHarmonyAttributes = true;
+            return hasHarmonyAttributes;
+        }
+    }
+}

--- a/BepInEx.Analyzers/BepInEx.Analyzers/HarmonyUtil.cs
+++ b/BepInEx.Analyzers/BepInEx.Analyzers/HarmonyUtil.cs
@@ -6,9 +6,19 @@ namespace BepInEx.Analyzers
 {
     public static class HarmonyUtil
     {
-        // Check if the method or the class containing the method has Harmony related attributes
-        public static bool IsMethodHarmonyRelated(ref SyntaxNodeAnalysisContext context, MethodDeclarationSyntax method, ISymbol symbol)
+        // Check if the method is Harmony patch related :
+        // It is when its static and the HarmonyPatch attribute is present
+        // either on the method or the containing class
+        // Todo : When the attribute is on the class,
+        // check if the method name is any of the following :
+        // Prefix, Postfix, Transpiler, Finalizer etc
+        public static bool IsMethodHarmonyPatchRelated(ref SyntaxNodeAnalysisContext context, MethodDeclarationSyntax method, ISymbol symbol)
         {
+            if (!method.IsStatic())
+            {
+                return false;
+            }
+
             bool hasHarmonyAttributes = symbol.HasAttribute(TypeNames.HarmonyPatch);
             if (!hasHarmonyAttributes)
                 if (method.Parent is ClassDeclarationSyntax classDeclaration)
@@ -18,8 +28,13 @@ namespace BepInEx.Analyzers
         }
 
         // Same as above but from a SuppressionAnalysisContext context
-        public static bool IsMethodHarmonyRelated(ref SuppressionAnalysisContext context, SemanticModel semanticModel, MethodDeclarationSyntax method, ISymbol symbol)
+        public static bool IsMethodHarmonyPatchRelated(ref SuppressionAnalysisContext context, SemanticModel semanticModel, MethodDeclarationSyntax method, ISymbol symbol)
         {
+            if (!method.IsStatic())
+            {
+                return false;
+            }
+
             bool hasHarmonyAttributes = symbol.HasAttribute(TypeNames.HarmonyPatch);
             if (!hasHarmonyAttributes)
                 if (method.Parent is ClassDeclarationSyntax classDeclaration)

--- a/BepInEx.Analyzers/BepInEx.Analyzers/Resources.Designer.cs
+++ b/BepInEx.Analyzers/BepInEx.Analyzers/Resources.Designer.cs
@@ -142,6 +142,33 @@ namespace BepInEx.Analyzers {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Harmony non-ref patch parameter modified.
+        /// </summary>
+        internal static string HarmonyMethodRefParametersAnalyzerDescription {
+            get {
+                return ResourceManager.GetString("HarmonyMethodRefParametersAnalyzerDescription", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Harmony non-ref patch parameter {0} modified.
+        /// </summary>
+        internal static string HarmonyMethodRefParametersAnalyzerMessageFormat {
+            get {
+                return ResourceManager.GetString("HarmonyMethodRefParametersAnalyzerMessageFormat", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Harmony non-ref patch parameters modified.
+        /// </summary>
+        internal static string HarmonyMethodRefParametersAnalyzerTitle {
+            get {
+                return ResourceManager.GetString("HarmonyMethodRefParametersAnalyzerTitle", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Don&apos;t flag private methods with HarmonyPatch attribute as unused..
         /// </summary>
         internal static string HarmonyPrivateMethodSuppressorJustification {

--- a/BepInEx.Analyzers/BepInEx.Analyzers/Resources.Designer.cs
+++ b/BepInEx.Analyzers/BepInEx.Analyzers/Resources.Designer.cs
@@ -142,7 +142,7 @@ namespace BepInEx.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Harmony non-ref patch parameter modified.
+        ///   Looks up a localized string similar to Harmony non-ref patch parameter modified. This assignment have no effect..
         /// </summary>
         internal static string HarmonyMethodRefParametersAnalyzerDescription {
             get {
@@ -151,7 +151,7 @@ namespace BepInEx.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Harmony non-ref patch parameter {0} modified.
+        ///   Looks up a localized string similar to Harmony non-ref patch parameter {0} modified. This assignment have no effect..
         /// </summary>
         internal static string HarmonyMethodRefParametersAnalyzerMessageFormat {
             get {

--- a/BepInEx.Analyzers/BepInEx.Analyzers/Resources.resx
+++ b/BepInEx.Analyzers/BepInEx.Analyzers/Resources.resx
@@ -144,6 +144,15 @@
   <data name="BepInExMissingInheritanceAnalyzerTitle" xml:space="preserve">
     <value>Classes with BepInPlugin attribute must inherit from BaseUnityPlugin</value>
   </data>
+  <data name="HarmonyMethodRefParametersAnalyzerDescription" xml:space="preserve">
+    <value>Harmony non-ref patch parameter modified</value>
+  </data>
+  <data name="HarmonyMethodRefParametersAnalyzerMessageFormat" xml:space="preserve">
+    <value>Harmony non-ref patch parameter {0} modified</value>
+  </data>
+  <data name="HarmonyMethodRefParametersAnalyzerTitle" xml:space="preserve">
+    <value>Harmony non-ref patch parameters modified</value>
+  </data>
   <data name="HarmonyPrivateMethodSuppressorJustification" xml:space="preserve">
     <value>Don't flag private methods with HarmonyPatch attribute as unused.</value>
   </data>

--- a/BepInEx.Analyzers/BepInEx.Analyzers/Resources.resx
+++ b/BepInEx.Analyzers/BepInEx.Analyzers/Resources.resx
@@ -145,10 +145,10 @@
     <value>Classes with BepInPlugin attribute must inherit from BaseUnityPlugin</value>
   </data>
   <data name="HarmonyMethodRefParametersAnalyzerDescription" xml:space="preserve">
-    <value>Harmony non-ref patch parameter modified</value>
+    <value>Harmony non-ref patch parameter modified. This assignment have no effect.</value>
   </data>
   <data name="HarmonyMethodRefParametersAnalyzerMessageFormat" xml:space="preserve">
-    <value>Harmony non-ref patch parameter {0} modified</value>
+    <value>Harmony non-ref patch parameter {0} modified. This assignment have no effect.</value>
   </data>
   <data name="HarmonyMethodRefParametersAnalyzerTitle" xml:space="preserve">
     <value>Harmony non-ref patch parameters modified</value>


### PR DESCRIPTION
And also
- Minor fix : HarmonyPropertyPatchAnalyzer check for null ref on `attribute.ArgumentList` : the HarmonyPatch attribute can have no arguments.