### PR TITLE
Fix a case for harmony non-ref parameter analyzer and null ref exception for publicized accesses analyzer

### DIFF
--- a/BepInEx.Analyzers/BepInEx.Analyzers.Package/BepInEx.Analyzers.Package.csproj
+++ b/BepInEx.Analyzers/BepInEx.Analyzers.Package/BepInEx.Analyzers.Package.csproj
@@ -11,7 +11,7 @@
 
   <PropertyGroup>
     <PackageId>BepInEx.Analyzers</PackageId>
-    <PackageVersion>1.0.7</PackageVersion>
+    <PackageVersion>1.0.8</PackageVersion>
     <Authors>BepInEx</Authors>
     <PackageProjectUrl>https://github.com/BepInEx/BepInEx.Analyzers</PackageProjectUrl>
     <PackageIconUrl>https://avatars2.githubusercontent.com/u/39589027</PackageIconUrl>

--- a/BepInEx.Analyzers/BepInEx.Analyzers/AccessPublicizedMemberAnalyzer.cs
+++ b/BepInEx.Analyzers/BepInEx.Analyzers/AccessPublicizedMemberAnalyzer.cs
@@ -53,7 +53,7 @@ namespace BepInEx.Analyzers
         {
             var memberAccess = (MemberAccessExpressionSyntax)context.Node;
             var symbol = context.SemanticModel.GetSymbolInfo(memberAccess.Name, context.CancellationToken).Symbol;
-            
+
             if (symbol == null)
                 return;
 
@@ -62,12 +62,12 @@ namespace BepInEx.Analyzers
                 var propertyUsage = context.Node.GetPropertyUsage();
                 if (propertyUsage == Extensions.PropertyUsage.Get || propertyUsage == Extensions.PropertyUsage.GetAndSet)
                 {
-                    var getMethodPublicizedAttribute = propertySymbol.GetMethod.GetAttribute(PublicizedAttributeName);
+                    var getMethodPublicizedAttribute = propertySymbol.GetMethod?.GetAttribute(PublicizedAttributeName);
                     Check(getMethodPublicizedAttribute, symbol, context, memberAccess);
                 }
                 else
                 {
-                    var setMethodPublicizedAttribute = propertySymbol.SetMethod.GetAttribute(PublicizedAttributeName);
+                    var setMethodPublicizedAttribute = propertySymbol.SetMethod?.GetAttribute(PublicizedAttributeName);
                     Check(setMethodPublicizedAttribute, symbol, context, memberAccess);
                 }
             }

--- a/BepInEx.Analyzers/BepInEx.Analyzers/HarmonyMethodRefParametersAnalyzer.cs
+++ b/BepInEx.Analyzers/BepInEx.Analyzers/HarmonyMethodRefParametersAnalyzer.cs
@@ -61,7 +61,8 @@ namespace BepInEx.Analyzers
                 foreach (var parameter in method.ParameterList.Parameters)
                 {
                     // If parameter is a reference type and is not a literal assignment no warning needed
-                    if (context.SemanticModel.GetDeclaredSymbol(parameter, context.CancellationToken).Type.IsReferenceType)
+                    var parameterSymbol = context.SemanticModel.GetDeclaredSymbol(parameter, context.CancellationToken);
+                    if (parameterSymbol.Type.IsReferenceType)
                     {
                         if (!(expressionSyntaxes[i] is AssignmentExpressionSyntax assignment))
                         {
@@ -69,9 +70,8 @@ namespace BepInEx.Analyzers
                         }
                     }
 
-                    // TODO : Looking through the ToString() and "ref" is not the cleanest
-                    var parameterSplit = parameter.ToString().Split(' ');
-                    if (parameterSplit.Any(s => s == varNames[i]) && !parameterSplit.Any(s => s == "ref" || s == "out"))
+                    var paramaterName = parameterSymbol.Name;
+                    if (parameterSymbol.RefKind == RefKind.None && paramaterName == varNames[i])
                     {
                         context.ReportDiagnostic(Diagnostic.Create(Rule, expressionSyntaxes[i].GetLocation(), expressionSyntaxes[i].ToString()));
                     }

--- a/BepInEx.Analyzers/BepInEx.Analyzers/HarmonyMethodRefParametersAnalyzer.cs
+++ b/BepInEx.Analyzers/BepInEx.Analyzers/HarmonyMethodRefParametersAnalyzer.cs
@@ -70,8 +70,8 @@ namespace BepInEx.Analyzers
                         }
                     }
 
-                    var paramaterName = parameterSymbol.Name;
-                    if (parameterSymbol.RefKind == RefKind.None && paramaterName == varNames[i])
+                    var parameterName = parameterSymbol.Name;
+                    if (parameterSymbol.RefKind == RefKind.None && parameterName == varNames[i])
                     {
                         context.ReportDiagnostic(Diagnostic.Create(Rule, expressionSyntaxes[i].GetLocation(), expressionSyntaxes[i].ToString()));
                     }


### PR DESCRIPTION
![enum](https://media.discordapp.net/attachments/624272422295568435/935198438767878164/Harmoney003.png)

the type name was wrongly taken for a symbol name because of the ToString().ToSplit code

Also fix a potential null ref exception in access publicized member analyzer