### PR TITLE
Fix HarmonyMethodRefParametersAnalyzer incorrectly marking member accesses as warning

### DIFF
--- a/BepInEx.Analyzers/BepInEx.Analyzers.Package/BepInEx.Analyzers.Package.csproj
+++ b/BepInEx.Analyzers/BepInEx.Analyzers.Package/BepInEx.Analyzers.Package.csproj
@@ -11,7 +11,7 @@
 
   <PropertyGroup>
     <PackageId>BepInEx.Analyzers</PackageId>
-    <PackageVersion>1.0.8</PackageVersion>
+    <PackageVersion>1.0.9</PackageVersion>
     <Authors>BepInEx</Authors>
     <PackageProjectUrl>https://github.com/BepInEx/BepInEx.Analyzers</PackageProjectUrl>
     <PackageIconUrl>https://avatars2.githubusercontent.com/u/39589027</PackageIconUrl>

--- a/BepInEx.Analyzers/BepInEx.Analyzers/HarmonyMethodRefParametersAnalyzer.cs
+++ b/BepInEx.Analyzers/BepInEx.Analyzers/HarmonyMethodRefParametersAnalyzer.cs
@@ -40,17 +40,9 @@ namespace BepInEx.Analyzers
             if (method.ParameterList?.Parameters.Count <= 0)
                 return;
 
-            var memberAccesses = context.Node.DescendantNodes().OfType<MemberAccessExpressionSyntax>();
-            var varNames = memberAccesses.Select(e => e.Expression.ToString()).ToList();
-            CheckExpressionSyntaxes(context, method, varNames, memberAccesses.Cast<ExpressionSyntax>().ToList());
-
             var assignments = context.Node.DescendantNodes().OfType<AssignmentExpressionSyntax>();
-            varNames = assignments.Select(e => e.Left.ToString()).ToList();
+            var varNames = assignments.Select(e => e.Left.ToString()).ToList();
             CheckExpressionSyntaxes(context, method, varNames, assignments.Cast<ExpressionSyntax>().ToList());
-
-            var accessesByIndex = context.Node.DescendantNodes().OfType<ElementAccessExpressionSyntax>();
-            varNames = accessesByIndex.Select(e => e.Expression.ToString()).ToList();
-            CheckExpressionSyntaxes(context, method, varNames, accessesByIndex.Cast<ExpressionSyntax>().ToList());
         }
 
         private static void CheckExpressionSyntaxes(SyntaxNodeAnalysisContext context, MethodDeclarationSyntax method,
@@ -60,15 +52,7 @@ namespace BepInEx.Analyzers
             {
                 foreach (var parameter in method.ParameterList.Parameters)
                 {
-                    // If parameter is a reference type and is not a literal assignment no warning needed
                     var parameterSymbol = context.SemanticModel.GetDeclaredSymbol(parameter, context.CancellationToken);
-                    if (parameterSymbol.Type.IsReferenceType)
-                    {
-                        if (!(expressionSyntaxes[i] is AssignmentExpressionSyntax assignment))
-                        {
-                            continue;
-                        }
-                    }
 
                     var parameterName = parameterSymbol.Name;
                     if (parameterSymbol.RefKind == RefKind.None && parameterName == varNames[i])


### PR DESCRIPTION
Fix incorrect warnings like these ![incorrect warning](https://cdn.discordapp.com/attachments/624272422295568435/936453105086763079/analyzerIssue.png)